### PR TITLE
+ Qt6-compatible CMakeLists

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,7 @@ cmake_minimum_required(VERSION 3.2)
 # version 3.4 is required as other do not work with C++14 and clang
 
 project(NodeEditor CXX)
+cmake_policy(SET CMP0072 NEW)
 
 set(CMAKE_DISABLE_IN_SOURCE_BUILD ON)
 set(CMAKE_DISABLE_SOURCE_CHANGES  ON)
@@ -38,13 +39,21 @@ endif()
 
 add_subdirectory(external)
 
+find_package(QT NAMES Qt6 Qt5 COMPONENTS Core Widgets Gui REQUIRED)
+
+message(STATUS "Using Qt" ${QT_VERSION_MAJOR})
+
 # Find the QtWidgets library
-find_package(Qt5 5.10 COMPONENTS
+find_package(Qt${QT_VERSION_MAJOR} 5.10 COMPONENTS
              Core
              Widgets
              Gui)
 
-qt5_add_resources(RESOURCES ./resources/nodeeditor.qrc)
+if(${QT_VERSION_MAJOR} LESS 6)
+    qt5_add_resources(RESOURCES ./resources/nodeeditor.qrc)
+else()
+    qt_add_resources(RESOURCES ./resources/nodeeditor.qrc)
+endif()
 
 # Unfortunately, as we have a split include/src, AUTOMOC doesn't work.
 # We'll have to manually specify some files
@@ -93,14 +102,13 @@ target_include_directories(nodes
 
 target_link_libraries(nodes
   PUBLIC
-    Qt5::Core
-    Qt5::Widgets
-    Qt5::Gui
+    Qt${QT_VERSION_MAJOR}::Core
+    Qt${QT_VERSION_MAJOR}::Widgets
+    Qt${QT_VERSION_MAJOR}::Gui
 )
 
 target_compile_definitions(nodes
   PUBLIC
-    ${Qt5Widgets_DEFINITIONS}
     NODE_EDITOR_SHARED
   PRIVATE
     NODE_EDITOR_EXPORTS
@@ -133,11 +141,19 @@ set_target_properties(nodes
 
 file(GLOB_RECURSE HEADERS_TO_MOC include/nodes/internal/*.hpp)
 
-qt5_wrap_cpp(nodes_moc
-    ${HEADERS_TO_MOC}
-  TARGET nodes
-  OPTIONS --no-notes # Don't display a note for the headers which don't produce a moc_*.cpp
-)
+if(${QT_VERSION_MAJOR} LESS 6)
+    qt5_wrap_cpp(nodes_moc
+        ${HEADERS_TO_MOC}
+      TARGET nodes
+      OPTIONS --no-notes # Don't display a note for the headers which don't produce a moc_*.cpp
+    )
+else()
+    qt_wrap_cpp(nodes_moc
+        ${HEADERS_TO_MOC}
+      TARGET nodes
+      OPTIONS --no-notes # Don't display a note for the headers which don't produce a moc_*.cpp
+    )
+endif()
 
 target_sources(nodes PRIVATE ${nodes_moc})
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
-cmake_minimum_required(VERSION 3.2)
 # version 3.4 is required as other do not work with C++14 and clang
+cmake_minimum_required(VERSION 3.4)
 
 project(NodeEditor CXX)
 cmake_policy(SET CMP0072 NEW)

--- a/src/FlowScene.cpp
+++ b/src/FlowScene.cpp
@@ -673,7 +673,7 @@ void FlowScene::pasteNodes(const QByteArray& data, const QPointF& pointOffset)
    {
       auto nodeJson = node.toObject();
 
-      QString oldId = nodeJson["id"].toString();
+      QUuid oldId = QUuid::fromString(nodeJson["id"].toString());
       if (!newIdsMap.contains(oldId))
          newIdsMap[oldId] = QUuid::createUuid();
 
@@ -694,11 +694,11 @@ void FlowScene::pasteNodes(const QByteArray& data, const QPointF& pointOffset)
    {
       auto connectionJson = connection.toObject();
 
-      QString oldId = connectionJson["in_id"].toString();
+      QUuid oldId = QUuid::fromString(connectionJson["in_id"].toString());
       if (newIdsMap.contains(oldId))
          connectionJson["in_id"] = newIdsMap[oldId].toString();
 
-      oldId = connectionJson["out_id"].toString();
+      oldId = QUuid::fromString(connectionJson["out_id"].toString());
       if (newIdsMap.contains(oldId))
          connectionJson["out_id"] = newIdsMap[oldId].toString();
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,5 +1,5 @@
 find_package(Catch2 2.3.0 REQUIRED)
-find_package(Qt5 COMPONENTS Test)
+find_package(Qt${QT_VERSION_MAJOR} COMPONENTS Test)
 
 add_executable(test_nodes
   test_main.cpp
@@ -20,7 +20,7 @@ target_link_libraries(test_nodes
   PRIVATE
     NodeEditor::nodes
     Catch2::Catch2
-    Qt5::Test
+    Qt${QT_VERSION_MAJOR}::Test
 )
 
 add_test(


### PR DESCRIPTION
This enables building NodeEditor against Qt6.

Changes:

- Use Qt6 first if it exists.
- Use Qt versionless CMake functions for Qt6
- Used a function `QUuid::fromString`, this is ok since the function `fromString` is introduced since Qt 5.10, which is exactly the minimum required version specified by the CMakeLists.