### PR TITLE
cmake/NodeEditorConfig.cmake.in: Added missing Qt6 support

### DIFF
--- a/cmake/NodeEditorConfig.cmake.in
+++ b/cmake/NodeEditorConfig.cmake.in
@@ -4,7 +4,7 @@ include(CMakeFindDependencyMacro)
 
 # NOTE Had to use find_package because find_dependency does not support COMPONENTS or MODULE until 3.8.0
 
-find_package(Qt5 REQUIRED COMPONENTS
+find_package(Qt@QT_VERSION_MAJOR@ REQUIRED COMPONENTS
              Core
              Widgets
              Gui


### PR DESCRIPTION
This PR adds Qt6 support for `cmake/NodeEditorConfig.cmake.in`.